### PR TITLE
Have check-requirements ignore URLs since that seems to choke the parser

### DIFF
--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -47,6 +47,9 @@ def get_raw_requirements(filename):
         (parse_requirement(line), filename)
         for line in lines
         if not line.startswith('-e ')
+        # Not just 'http' because that's a valid package name, look for urls
+        and not line.startswith('https://')
+        and not line.startswith('http://')
     ]
 
 

--- a/tests/check_requirements_test.py
+++ b/tests/check_requirements_test.py
@@ -44,9 +44,25 @@ def test_get_raw_requirements_trivial(tmpdir):
     assert main.get_raw_requirements(reqs_filename.strpath) == []
 
 
-def test_get_raw_requirements_some_things(tmpdir):
+def test_get_raw_requirements_ignores_editable_mode(tmpdir):
     reqs_file = tmpdir.join('requirements.txt')
     reqs_file.write('-e .\nfoo==1\nbar==2')
+    requirements = main.get_raw_requirements(reqs_file.strpath)
+    assert requirements == [
+        (pkg_resources.Requirement.parse('foo==1'), reqs_file.strpath),
+        (pkg_resources.Requirement.parse('bar==2'), reqs_file.strpath),
+    ]
+
+
+def test_get_raw_requirements_ignores_urls(tmpdir):
+    reqs_file = tmpdir.join('requirements.txt')
+    req_str = '\n'.join([
+        'http://example.com',
+        'https://github.com',
+        'foo==1',
+        'bar==2',
+    ])
+    reqs_file.write(req_str)
     requirements = main.get_raw_requirements(reqs_file.strpath)
     assert requirements == [
         (pkg_resources.Requirement.parse('foo==1'), reqs_file.strpath),


### PR DESCRIPTION
I'm trying to use `check-requirements` tool on my project and it's choking on some of the github links we have in there (see error below). Not sure about your stance on whether or not it _should_ be checking URLs, but I figured I'd submit this pull-request as an opening in that conversation :)

```
______________________________________________________________ ERROR at setup of test_no_underscores_all_dashes _______________________________________________________________
../env/lib/python2.7/site-packages/requirements_tools/check_requirements.py:149: in check_requirements_integrity
    raw_requirements = _get_all_raw_requirements()
../env/lib/python2.7/site-packages/requirements_tools/check_requirements.py:143: in _get_all_raw_requirements
    if os.path.exists(reqfile)
../env/lib/python2.7/site-packages/requirements_tools/check_requirements.py:49: in get_raw_requirements
    if not line.startswith('-e ')
../env/lib/python2.7/site-packages/requirements_tools/check_requirements.py:23: in parse_requirement
    dumb_parse = pkg_resources.Requirement.parse(req)
../env/lib/python2.7/site-packages/pkg_resources/__init__.py:2895: in parse
    req, = parse_requirements(s)
../env/lib/python2.7/site-packages/pkg_resources/__init__.py:2843: in parse_requirements
    yield Requirement(line)
../env/lib/python2.7/site-packages/pkg_resources/__init__.py:2852: in __init__
    raise RequirementParseError(str(e))
E   RequirementParseError: Invalid requirement, parse error at "u'://githu'"
```