### PR TITLE
Add --dev-only flag to upgrade-requirements and check-requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup(
     name='requirements-tools',
     description='Scripts for working with Python requirements.',
-    version='1.2.0',
+    version='2.0.0',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
requirements-tools is meant for applications rather than libraries, but we frequently want to pin dev dependencies in libraries to ensure reproducible test runs. One workaround is to add an empty `requirements-minimal.txt` file to a library, but this can cause confusion. This PR adds a --dev-only flag to upgrade-requirements and check-requirements to only operate on `requirements-dev-minimal.txt` and `requirements-dev.txt`.

Rather than using constants for requirements files, this change uses a pytest plugin to parametrize which files the tests should look at, while maintaining existing structure as much as possible.