### PR TITLE
Support environment markers

### DIFF
--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -398,7 +398,7 @@ def test_no_underscores_all_dashes(requirements_files=REQUIREMENTS_FILES):
         if not os.path.exists(requirement_file):
             continue
         for line in get_lines_from_file(requirement_file):
-            if '_' in line:
+            if '_' in line.split(';')[0]:
                 raise AssertionError(
                     'Use dashes for package names {}: {}'.format(
                         requirement_file, line,

--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -398,6 +398,7 @@ def test_no_underscores_all_dashes(requirements_files=REQUIREMENTS_FILES):
         if not os.path.exists(requirement_file):
             continue
         for line in get_lines_from_file(requirement_file):
+            # ignore the markers for underscore check
             if '_' in line.split(';')[0]:
                 raise AssertionError(
                     'Use dashes for package names {}: {}'.format(


### PR DESCRIPTION
Fix `test_no_underscores_all_dashes` so that environment markers (https://www.python.org/dev/peps/pep-0508/) will not fail tests. Decided not to change `parse_requirement` since I'm not sure that there's any particular validation to be done on the markers.