### PR TITLE
Install setuptools and wheel from index-url in upgrade-requirements

### DIFF
--- a/requirements_tools/upgrade_requirements.py
+++ b/requirements_tools/upgrade_requirements.py
@@ -105,6 +105,7 @@ def make_virtualenv(args):
         print_call(
             sys.executable, '-m', 'virtualenv', venv,
             '-p', args.python, '--never-download',
+            '--no-wheel', '--no-setuptools',
         )
 
         def pip_install(pip, *argv):
@@ -112,7 +113,8 @@ def make_virtualenv(args):
 
         # Latest pip installs python3.5 wheels
         pip_install(
-            (pip,), '--upgrade', 'setuptools', 'pip', args.install_deps,
+            (pip,), '--upgrade', 'setuptools', 'pip', 'wheel',
+            args.install_deps,
         )
         pip_install(pip_tool, '-r', 'requirements-minimal.txt')
         pip_install(pip_tool, '-r', 'requirements-dev-minimal.txt')


### PR DESCRIPTION
Resolves CORESERV-7442.

If virtualenv installs setuptools and wheel from public pypi, then those packages are cached and reused when determining upgraded packages. This is a problem if the versions of setuptools and wheel in index-url are different from public pypi.

This PR forces setuptools and wheel to be installed from index-url if it is specified.