### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-project = requirements_tools
 envlist = py27,py35
 
 [testenv]
@@ -12,8 +11,3 @@ commands =
     coverage report --show-missing --fail-under 64
     pre-commit install -f --install-hooks
     pre-commit run --all-files
-
-[testenv:venv]
-basepython = python2.7
-envdir = venv-{[tox]project}
-commands =


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos