### PR TITLE
Add a max-depth option to visualize-requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ it).
 
 To use it, just call `visualize-requirements requirements.txt`.
 
+You may find that your application has a large dependency tree so that the
+default output becomes hard to read. You can specify a `--max-depth` option
+so that the output is easier to read:
+`visualize-requirements --max-depth 1 requirements.txt`.
+
 ## check-all-wheels
 
 This tool checks whether all of your dependencies are pre-wheeled on the

--- a/requirements_tools/visualize_requirements.py
+++ b/requirements_tools/visualize_requirements.py
@@ -31,7 +31,10 @@ def get_raw_requirements(requirements_file):
     )
 
 
-def print_req(req, depth, seen=()):
+def print_req(req, depth, max_depth, seen=()):
+    if max_depth >= 0 and depth > max_depth:
+        return
+
     if req.key in seen:
         circular = ' (circular: {})'.format(
             '->'.join(seen[seen.index(req.key):] + (req.key,)),
@@ -63,17 +66,28 @@ def print_req(req, depth, seen=()):
         return
 
     for sub_requirement in reqs[req.key].requires(req.extras):
-        print_req(sub_requirement, depth + 1, seen=seen + (req.key,))
+        print_req(
+            sub_requirement,
+            depth + 1,
+            max_depth,
+            seen=seen + (req.key,),
+        )
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('requirements_file')
+    parser.add_argument(
+        '--max-depth',
+        type=int,
+        default=-1,
+        help='max dependency depth to print (inclusive)',
+    )
     args = parser.parse_args()
 
     raw_requirements = get_raw_requirements(args.requirements_file)
     for requirement in raw_requirements:
-        print_req(requirement, 0)
+        print_req(requirement, 0, args.max_depth)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In medium-sized applications you can end up with large unreadable output from this tool. This commit adds a max- depth option so that users can limit the amount of output that the tool produces. The default is to print everything, as it was before.

Example: Yelp/paasta depends on `bravado`. `visualize-requirements` will thus print this out for `bravado`:
```
 bravado==10.4.1
   - six
   - python-dateutil
     - six>=1.5
   - simplejson
   - monotonic
   - bravado-core>=5.0.1
     - six
     - pyyaml
     - python-dateutil
       - six>=1.5
     - jsonref
     - msgpack-python>=0.5.2
     - pytz
     - simplejson
     - jsonschema[format]>=2.5.1
       - rfc3987
       - webcolors
       - strict-rfc3339
     - swagger-spec-validator>=2.0.1
       - six
       - jsonschema
   - typing-extensions
   - requests>=2.4
     - chardet>=3.0.2,<3.1.0
     - certifi>=2017.4.17
     - idna<2.9,>=2.5
     - urllib3<1.25,>=1.21.1
   - msgpack-python
   - pyyaml
```

If you set `--max-depth=1` you'll end up with this output:
```
 bravado==10.4.1
   - bravado-core>=5.0.1
   - msgpack-python
   - six
   - typing-extensions
   - simplejson
   - pyyaml
   - monotonic
   - python-dateutil
   - requests>=2.4
```
which is a lot more compact. If you `requirements.txt` passes `check-requirements`, you also don't lose any information, since the sub-dependencies will be listed elsewhere.

## Another possible approach
Another option I thought to make `visualize-requirements` easier to read, was to make this tool output json, and then users can do some `jq` magic to get what they want. I didn't go with this because it seems like it's a less trivial change than this due to how the existing recursion is set up, and this option depends on users having `jq` installed.