### PR TITLE
separate installing setuptools pip from others

### DIFF
--- a/requirements_tools/upgrade_requirements.py
+++ b/requirements_tools/upgrade_requirements.py
@@ -112,8 +112,9 @@ def make_virtualenv(args):
 
         # Latest pip installs python3.5 wheels
         pip_install(
-            (pip,), '--upgrade', 'setuptools', 'pip', args.install_deps,
+            (pip,), '--upgrade', 'setuptools', 'pip',
         )
+        pip_install((pip,), args.install_deps)
         pip_install(pip_tool, '-r', 'requirements-minimal.txt')
         pip_install(pip_tool, '-r', 'requirements-dev-minimal.txt')
 


### PR DESCRIPTION
This separation makes other dependencies be able to include pip or setuptools as well in case they need to be downgraded.