### PR TITLE
Don't default index url to public pypi. Defer to underlying libs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.5
+python: 3.6
 env:  # These should match the tox env list.
     - TOXENV=py27
     - TOXENV=py36

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python: 3.5
 env:  # These should match the tox env list.
     - TOXENV=py27
-    - TOXENV=py35
+    - TOXENV=py36
 install: pip install coveralls tox
 script: tox
 after_success: coveralls

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 -e .
 # Triggers WEBCORE-3776
 chameleon==2.13.post1
-coverage
+# Remove constraint once off python 3.6.0 on xenial
+coverage<5
 mock
 pre-commit
 pytest

--- a/requirements_tools/check_all_wheels.py
+++ b/requirements_tools/check_all_wheels.py
@@ -16,9 +16,7 @@ DISTS_DIR = 'downloaded_dists'
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-i', '--index-url', default='https://pypi.python.org/simple',
-    )
+    parser.add_argument('-i', '--index-url')
     parser.add_argument('--pip-tool', default='pip')
     parser.add_argument('--install-deps', default='pip')
     args = parser.parse_args()
@@ -31,12 +29,22 @@ def main():
     os.makedirs(DISTS_DIR)
 
     silent('pip', 'install', 'pip', '--upgrade')
-    silent('pip', 'install', '-i', args.index_url, args.install_deps)
+
+    if args.index_url:
+        silent('pip', 'install', '-i', args.index_url, args.install_deps)
+    else:
+        silent('pip', 'install', args.install_deps)
+
     cmd = tuple(shlex.split(args.pip_tool)) + (
-        'download', '--dest', DISTS_DIR,
-        '-r', 'requirements.txt', '-r', 'requirements-dev.txt',
-        '-i', args.index_url,
+        'download',
+        '--dest', DISTS_DIR,
+        '-r', 'requirements.txt',
+        '-r', 'requirements-dev.txt',
     )
+
+    if args.index_url:
+        cmd = cmd + ('-i', args.index_url)
+
     silent(*cmd)
 
     ret = 0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup(
     name='requirements-tools',
     description='Scripts for working with Python requirements.',
-    version='1.2.5',
+    version='2.0.0',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,13 @@ from setuptools import setup
 setup(
     name='requirements-tools',
     description='Scripts for working with Python requirements.',
-    version='1.2.4',
+    version='1.2.5',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     install_requires=['pytest', 'virtualenv'],
     packages=find_packages(exclude=('tests*',)),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py36
 
 [testenv]
 deps = -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,6 @@ commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
     # TODO(ckuehl|#1): raise this to 100
-    coverage report --show-missing --fail-under 64
+    coverage report --show-missing --fail-under 63
     pre-commit install -f --install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
Testing done: `tox -e upgrade-requirements' now works with serviecs/ad_realtime_bidding

Internal ticket: CORESERV-10904