### PR TITLE
Support --extra-index-url

### DIFF
--- a/requirements_tools/check_all_wheels.py
+++ b/requirements_tools/check_all_wheels.py
@@ -17,6 +17,7 @@ DISTS_DIR = 'downloaded_dists'
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', '--index-url')
+    parser.add_argument('--extra-index-url')
     parser.add_argument('--pip-tool', default='pip')
     parser.add_argument('--install-deps', default='pip')
     args = parser.parse_args()
@@ -30,10 +31,12 @@ def main():
 
     silent('pip', 'install', 'pip', '--upgrade')
 
+    cmd = ('pip', 'install', args.install_deps)
     if args.index_url:
-        silent('pip', 'install', '-i', args.index_url, args.install_deps)
-    else:
-        silent('pip', 'install', args.install_deps)
+        cmd += ('-i', args.index_url)
+    if args.extra_index_url:
+        cmd += ('--extra-index-url', args.extra_index_url)
+    silent(*cmd)
 
     cmd = tuple(shlex.split(args.pip_tool)) + (
         'download',
@@ -44,6 +47,8 @@ def main():
 
     if args.index_url:
         cmd = cmd + ('-i', args.index_url)
+    if args.extra_index_url:
+        cmd = cmd + ('--extra-index-url', args.extra_index_url)
 
     silent(*cmd)
 

--- a/requirements_tools/upgrade_requirements.py
+++ b/requirements_tools/upgrade_requirements.py
@@ -110,7 +110,9 @@ def make_virtualenv(args):
         def pip_install(pip, *argv):
             install = ('install',)
             if args.index_url:
-                install = ('install', '-i', args.index_url)
+                install += ('-i', args.index_url)
+            if args.extra_index_url:
+                install += ('--extra-index-url', args.extra_index_url)
             print_call(*(pip + install + argv))
 
         # Latest pip installs python3.5 wheels
@@ -133,6 +135,8 @@ def make_virtualenv(args):
 
         if args.index_url:
             reexec_args.extend(('--index-url', args.index_url))
+        if args.extra_index_url:
+            reexec_args.extend(('--extra-index-url', args.extra_index_url))
 
         reexec(*reexec_args, reason='to use the virtualenv python')
 
@@ -144,6 +148,7 @@ def main():
         default='python' + '.'.join(str(x) for x in sys.version_info[:2]),
     )
     parser.add_argument('-i', '--index-url')
+    parser.add_argument('--extra-index-url')
     parser.add_argument(
         '--exec-limit', type=int, default=10, help=argparse.SUPPRESS,
     )


### PR DESCRIPTION
`--extra-index-url` is helpful for combining internal and external dependencies, when you don't want to go the whole nine yards and host all your dependencies with wheels, etc. I added support for it in upgrade-requirements and check-all-wheels, I've tested the upgrade-requirements well since I use it myself, but not check-all-wheels. I'm not sure if this is a patch you want to take, but if so, here it is :)