### PR TITLE
Update description to be more specific when checking if new package is needed

### DIFF
--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -394,7 +394,8 @@ def test_top_level_dependencies():
                 '\n'
                 'Usually this happens because you upgraded some other dependency, and now no longer require these.\n'  # noqa
                 "If that's the case, you should remove these from {pin}.\n"  # noqa
-                'Otherwise, if you *do* need these packages, then add them to {minimal}.\n'  # noqa
+                'Otherwise, if you *do* need these packages, which there is existing import of this package in your logic,'  # noqa
+                'then add them to {minimal}.\n'  # noqa
                 '{}'.format(
                     format_versions_on_lines_with_dashes(
                         pinned_but_not_required,

--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -394,8 +394,8 @@ def test_top_level_dependencies():
                 '\n'
                 'Usually this happens because you upgraded some other dependency, and now no longer require these.\n'  # noqa
                 "If that's the case, you should remove these from {pin}.\n"  # noqa
-                'Otherwise, if you *do* need these packages, which there is existing import of this package in your logic,'  # noqa
-                'then add them to {minimal}.\n'  # noqa
+                'Otherwise, if you *do* need these packages, then add them to {minimal}.\n'  # noqa
+                'Verify that with actual usage of the package in your logic.'  # noqa
                 '{}'.format(
                     format_versions_on_lines_with_dashes(
                         pinned_but_not_required,


### PR DESCRIPTION
When it comes to the case that a package is been added to the repository, it's essential to know that where that logic is truly needed. Meaning that the package's component or function has been specifically imported to the code logic.

Feeling the term `you do need these package` might not be clear enough when it comes to the case that an automatic dependency management system helps you adding some packages due to transiting requirements by other dependencies, but it's not actually need for the service itself. Let the language being more specific will help the developers not assuming that the auto-addition does not mean it's truly needed, you might still need to head back to the logic and checkout if there is specific imports.