### PR TITLE
drop python 2 fix deprecation warning of pipes module, add type annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,16 @@ name: build
 on: push
 jobs:
   tox:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         tox:
-          - py27
-          - py36
+          - py38
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,4 +28,8 @@ repos:
     rev: v3.3.1
     hooks:
     -   id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+    -   id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v4.4.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -8,19 +8,24 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: requirements-txt-fixer
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+    rev: v2.0.1
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.4.0
+    rev: v3.9.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v1.0.0
+    rev: v2.4.0
     hooks:
     -   id: add-trailing-comma
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,5 @@ pre-commit
 pytest
 # Triggers WEBCORE-3023
 setuptools>=18.5
-six
 # A circular dependency
 sphinx==1.3.6

--- a/requirements_tools/check_all_wheels.py
+++ b/requirements_tools/check_all_wheels.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import argparse
 import os
 import shlex
@@ -6,7 +8,7 @@ import shutil
 import subprocess
 
 
-def silent(*cmd):
+def silent(*cmd: str) -> None:
     with open(os.devnull, 'w') as devnull:
         subprocess.check_call(cmd, stdout=devnull)
 
@@ -14,7 +16,7 @@ def silent(*cmd):
 DISTS_DIR = 'downloaded_dists'
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', '--index-url')
     parser.add_argument('--pip-tool', default='pip')

--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -72,7 +72,7 @@ def get_raw_requirements(filename):
                 continue
 
             ret.append((parse_requirement(line), filename))
-        except pkg_resources.RequirementParseError as e:
+        except ValueError as e:
             raise AssertionError(
                 'Requirements must be <<pkg>> or <<pkg>>==<<version>>\n'
                 ' - git / http / etc. urls may be mutable (unpinnable)\n'

--- a/requirements_tools/check_requirements.py
+++ b/requirements_tools/check_requirements.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
-import io
 import itertools
 import os.path
 import sys
@@ -38,7 +33,7 @@ def parse_requirement(req):
 
 
 def get_lines_from_file(filename):
-    with io.open(filename) as requirements_file:
+    with open(filename) as requirements_file:
         return [
             line.strip() for line in requirements_file
             if line.strip() and not line.startswith('#')
@@ -96,7 +91,7 @@ def to_version(requirement):
 
 
 def to_equality_str(requirement):
-    return '{}=={}'.format(requirement.key, to_version(requirement))
+    return f'{requirement.key}=={to_version(requirement)}'
 
 
 def to_pinned_versions(requirements):
@@ -137,7 +132,7 @@ def format_unpinned_requirements(unpinned_requirements):
             package,
             requirement,
             filename,
-            '{}=={}'.format(package, installed_things[package].version),
+            f'{package}=={installed_things[package].version}',
         )
         for package, requirement, filename in sorted(
             unpinned_requirements,
@@ -205,7 +200,7 @@ def _check_requirements_integrity_impl():
             )
         installed_version = to_version(
             parse_requirement(
-                '{}=={}'.format(req.key, installed_things[req.key].version),
+                f'{req.key}=={installed_things[req.key].version}',
             ),
         )
         if installed_version != version:
@@ -300,14 +295,14 @@ def get_pinned_versions_from_requirement(requirement):
                     ),
                 )
             expected_pinned.add(
-                '{}=={}'.format(installed.key, installed.version),
+                f'{installed.key}=={installed.version}',
             )
     return expected_pinned
 
 
 def format_versions_on_lines_with_dashes(versions):
     return '\n'.join(
-        '\t- {}'.format(req)
+        f'\t- {req}'
         for req in sorted(versions, key=attrgetter('key'))
     )
 
@@ -321,7 +316,7 @@ def _expected_pinned(filename, pin_filename):
                 'Is it missing from {}?\n'
                 '\t- {}\n'.format(filename, pin_filename, req.key),
             )
-        ret.add('{}=={}'.format(req.key, installed_things[req.key].version))
+        ret.add(f'{req.key}=={installed_things[req.key].version}')
         ret |= get_pinned_versions_from_requirement(req)
     return ret
 
@@ -441,7 +436,7 @@ def test_no_underscores_all_dashes(requirements_files=REQUIREMENTS_FILES):
 
 def bold(text):  # pragma: no cover
     if sys.stderr.isatty():
-        return '\033[1m{}\033[0m'.format(text)
+        return f'\033[1m{text}\033[0m'
     else:
         return text
 

--- a/requirements_tools/upgrade_requirements.py
+++ b/requirements_tools/upgrade_requirements.py
@@ -2,7 +2,6 @@
 import argparse
 import contextlib
 import os
-import pipes
 import shlex
 import shutil
 import subprocess
@@ -28,7 +27,7 @@ def color(s, color):
 
 
 def fmt_cmd(cmd):
-    ret = '>>> {}'.format(' '.join(pipes.quote(x) for x in cmd))
+    ret = '>>> {}'.format(' '.join(shlex.quote(x) for x in cmd))
     return color(ret, '\033[32m')
 
 
@@ -40,7 +39,7 @@ def print_call(*cmd, **kwargs):
 def reexec(*cmd, **kwargs):
     reason = kwargs.pop('reason')
     assert not kwargs, kwargs
-    print(color('*** exec-ing: {}'.format(reason), '\033[33m'))
+    print(color(f'*** exec-ing: {reason}', '\033[33m'))
     print(fmt_cmd(cmd))
     # Never returns
     os.execv(cmd[0], cmd)
@@ -63,12 +62,12 @@ def installed(requirements_file):
         req = requirements_to_parse.pop()
         installed_req = installed_things[req.key]
         expected_pinned.add(
-            '{}=={}'.format(installed_req.project_name, installed_req.version),
+            f'{installed_req.project_name}=={installed_req.version}',
         )
         for sub in installed_req.requires(req.extras):
             if sub.key not in installed_things:
                 specifiers = ','.join(str(s) for s in sub.specifier)
-                unmet.add('{}{}'.format(sub.key, specifiers))
+                unmet.add(f'{sub.key}{specifiers}')
             elif (sub.key, sub.extras) not in already_parsed:
                 requirements_to_parse.append(sub)
                 already_parsed.add((sub.key, sub.extras))
@@ -128,7 +127,7 @@ def make_virtualenv(args):
             '--exec-count', str(args.exec_count),
             '--exec-limit', str(args.exec_limit),
             '--pip-tool', args.pip_tool,
-            '--install-deps={}'.format(args.install_deps),
+            f'--install-deps={args.install_deps}',
         ]
 
         if args.index_url:

--- a/requirements_tools/upgrade_requirements.py
+++ b/requirements_tools/upgrade_requirements.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import argparse
 import contextlib
 import os
@@ -7,6 +9,9 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from typing import Generator
+from typing import NoReturn
+from typing import Sequence
 
 from pkg_resources import Requirement
 from pkg_resources import working_set
@@ -19,24 +24,24 @@ class NeedsMoreInstalledError(RuntimeError):
     pass
 
 
-def color(s, color):
+def color(s: str, color: str) -> str:
     if sys.stdout.isatty():
         return '{}{}{}'.format(color, s, '\033[m')
     else:
         return s
 
 
-def fmt_cmd(cmd):
+def fmt_cmd(cmd: Sequence[str]) -> str:
     ret = '>>> {}'.format(' '.join(shlex.quote(x) for x in cmd))
     return color(ret, '\033[32m')
 
 
-def print_call(*cmd, **kwargs):
+def print_call(*cmd: str) -> None:
     print(fmt_cmd(cmd))
-    subprocess.check_call(cmd, **kwargs)
+    subprocess.check_call(cmd)
 
 
-def reexec(*cmd, **kwargs):
+def reexec(*cmd: str, **kwargs: str) -> NoReturn:
     reason = kwargs.pop('reason')
     assert not kwargs, kwargs
     print(color(f'*** exec-ing: {reason}', '\033[33m'))
@@ -45,14 +50,16 @@ def reexec(*cmd, **kwargs):
     os.execv(cmd[0], cmd)
 
 
-def requirements(requirements_filename):
+def requirements(
+        requirements_filename: str,
+) -> Generator[Requirement, None, None]:
     with open(requirements_filename) as requirements_file:
         for line in requirements_file:
             if line.strip() and not line.startswith(('#', '-e')):
                 yield Requirement.parse(line.strip())
 
 
-def installed(requirements_file):
+def installed(requirements_file: str) -> set[str]:
     expected_pinned = set()
     requirements_to_parse = list(requirements(requirements_file))
     already_parsed = {(req.key, req.extras) for req in requirements_to_parse}
@@ -66,7 +73,9 @@ def installed(requirements_file):
         )
         for sub in installed_req.requires(req.extras):
             if sub.key not in installed_things:
-                specifiers = ','.join(str(s) for s in sub.specifier)
+                specifiers = ','.join(
+                    str(s) for s in sub.specifier  # type: ignore[attr-defined]
+                )
                 unmet.add(f'{sub.key}{specifiers}')
             elif (sub.key, sub.extras) not in already_parsed:
                 requirements_to_parse.append(sub)
@@ -78,7 +87,7 @@ def installed(requirements_file):
         return expected_pinned
 
 
-def venv_paths(tmp, pip_tool):
+def venv_paths(tmp: str, pip_tool: str) -> tuple[str, ...]:
     dirnames = (
         'venv',
         'venv/bin/python',
@@ -89,25 +98,25 @@ def venv_paths(tmp, pip_tool):
 
 
 @contextlib.contextmanager
-def cleanup_dir(dirname):
+def cleanup_dir(dirname: str) -> Generator[str, None, None]:
     try:
         yield dirname
     finally:
         shutil.rmtree(dirname)
 
 
-def make_virtualenv(args):
+def make_virtualenv(args: argparse.Namespace) -> NoReturn:
     with cleanup_dir(tempfile.mkdtemp()) as tempdir:
-        venv, python, pip, pip_tool = venv_paths(tempdir, args.pip_tool)
-        pip_tool = tuple(shlex.split(pip_tool))
+        venv, python, pip, pip_tool_path = venv_paths(tempdir, args.pip_tool)
+        pip_tool = tuple(shlex.split(pip_tool_path))
 
         print_call(
             sys.executable, '-m', 'virtualenv', venv,
             '-p', args.python, '--never-download',
         )
 
-        def pip_install(pip, *argv):
-            install = ('install',)
+        def pip_install(pip: tuple[str, ...], *argv: str) -> None:
+            install: tuple[str, ...] = ('install',)
             if args.index_url:
                 install = ('install', '-i', args.index_url)
             print_call(*(pip + install + argv))
@@ -136,7 +145,7 @@ def make_virtualenv(args):
         reexec(*reexec_args, reason='to use the virtualenv python')
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-p', '--python',
@@ -160,8 +169,8 @@ def main():
     if args.tempdir is None:
         make_virtualenv(args)  # Never returns
 
-    venv, python, pip, pip_tool = venv_paths(args.tempdir, args.pip_tool)
-    pip_tool = tuple(shlex.split(pip_tool))
+    venv, python, pip, pip_tool_path = venv_paths(args.tempdir, args.pip_tool)
+    pip_tool = tuple(shlex.split(pip_tool_path))
 
     with cleanup_dir(args.tempdir):
         try:
@@ -175,7 +184,7 @@ def main():
                 raise AssertionError('--exec-limit depth limit exceeded')
             unmet, = e.args
 
-            install = ('install',)
+            install: tuple[str, ...] = ('install',)
             if args.index_url:
                 install = ('install', '-i', args.index_url)
             print_call(*(pip_tool + install + tuple(unmet)))
@@ -193,7 +202,7 @@ def main():
 
             reexec(*reexec_args, reason='Unmet dependencies')
 
-        def _file_contents(reqs):
+        def _file_contents(reqs: set[str]) -> str:
             if not reqs:
                 return ''
             else:
@@ -213,6 +222,7 @@ def main():
             os.path.join(venv, 'bin', 'requirements-txt-fixer'),
             'requirements.txt', 'requirements-dev.txt',
         ))
+    return 0
 
 
 if __name__ == '__main__':

--- a/requirements_tools/visualize_requirements.py
+++ b/requirements_tools/visualize_requirements.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import argparse
-import io
 import sys
 
 import pkg_resources
@@ -15,7 +11,7 @@ reqs = {pkg.key: pkg for pkg in pkg_resources.working_set}
 
 def get_lines_from_file(filename):
     """Returns the non-blank, non-comment lines from a requirements file."""
-    with io.open(filename, encoding='UTF-8') as requirements_file:
+    with open(filename, encoding='UTF-8') as requirements_file:
         return [
             line.strip() for line in requirements_file
             if line.strip() and not line.startswith('#')

--- a/requirements_tools/visualize_requirements.py
+++ b/requirements_tools/visualize_requirements.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python
+from __future__ import annotations
+
 import argparse
 import sys
+from typing import Generator
 
 import pkg_resources
+from pkg_resources import Requirement
 
 
 color = sys.stdout.isatty()
 reqs = {pkg.key: pkg for pkg in pkg_resources.working_set}
 
 
-def get_lines_from_file(filename):
+def get_lines_from_file(filename: str) -> list[str]:
     """Returns the non-blank, non-comment lines from a requirements file."""
     with open(filename, encoding='UTF-8') as requirements_file:
         return [
@@ -18,7 +22,9 @@ def get_lines_from_file(filename):
         ]
 
 
-def get_raw_requirements(requirements_file):
+def get_raw_requirements(
+        requirements_file: str,
+) -> Generator[Requirement, None, None]:
     """Get requirements from a requirements.txt file.  -r is not supported"""
     unparsed_requirements_lines = get_lines_from_file(requirements_file)
 
@@ -27,7 +33,11 @@ def get_raw_requirements(requirements_file):
     )
 
 
-def print_req(req, depth, seen=()):
+def print_req(
+        req: Requirement,
+        depth: int,
+        seen: tuple[str, ...] = (),
+) -> None:
     if req.key in seen:
         circular = ' (circular: {})'.format(
             '->'.join(seen[seen.index(req.key):] + (req.key,)),
@@ -62,7 +72,7 @@ def print_req(req, depth, seen=()):
         print_req(sub_requirement, depth + 1, seen=seen + (req.key,))
 
 
-def main():
+def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('requirements_file')
     args = parser.parse_args()
@@ -70,6 +80,7 @@ def main():
     raw_requirements = get_raw_requirements(args.requirements_file)
     for requirement in raw_requirements:
         print_req(requirement, 0)
+    return 0
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,16 @@
 [bdist_wheel]
 universal = true
+
+[mypy]
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+
+[mypy-testing.*]
+disallow_untyped_defs = false
+
+[mypy-tests.*]
+disallow_untyped_defs = false

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from setuptools import find_packages
 from setuptools import setup
 
@@ -14,6 +13,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
     ],
+    python_requires='>=3.8',
     install_requires=[
         'pytest',
         'virtualenv',

--- a/tests/check_requirements_test.py
+++ b/tests/check_requirements_test.py
@@ -482,8 +482,8 @@ def test_get_pinned_versions_from_requirement(requirement, expected_pkgs):
     )
     # These are to make this not flaky in future when things change
     assert isinstance(result, set)
-    result = sorted(result)
-    split = [req.split('==') for req in result]
+    result_list = sorted(result)
+    split = [req.split('==') for req in result_list]
     packages = [package for package, _ in split]
     assert packages == expected_pkgs
 

--- a/tests/check_requirements_test.py
+++ b/tests/check_requirements_test.py
@@ -1,9 +1,5 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import pkg_resources
 import pytest
-import six
 
 from requirements_tools import check_requirements as main
 
@@ -88,18 +84,11 @@ def test_get_raw_requirements_filter_by_environment_marker(tmpdir):
     reqs_file = tmpdir.join('requirements.txt')
     reqs_file.write(REQUIREMENTS_WITH_MARKERS)
     requirements = main.get_raw_requirements(reqs_file.strpath)
-    if six.PY2:
-        assert requirements == [
-            (
-                pkg_resources.Requirement.parse('foo==1'), reqs_file.strpath,
-            ),
-        ]
-    else:
-        assert requirements == [
-            (
-                pkg_resources.Requirement.parse('foo==2'), reqs_file.strpath,
-            ),
-        ]
+    assert requirements == [
+        (
+            pkg_resources.Requirement.parse('foo==2'), reqs_file.strpath,
+        ),
+    ]
 
 
 def test_to_version():
@@ -262,7 +251,7 @@ def test_test_top_level_dependencies_unmet_dependency(in_tmpdir):
 def test_prerelease_name_normalization(in_tmpdir, version):
     in_tmpdir.join('requirements-minimal.txt').write('prerelease-pkg')
     in_tmpdir.join('requirements.txt').write(
-        'prerelease-pkg=={}'.format(version),
+        f'prerelease-pkg=={version}',
     )
     main.test_top_level_dependencies()
 
@@ -546,7 +535,7 @@ def test_test_no_underscores_all_dashes_error(in_tmpdir):
             requirements_files=(tmpfile.strpath,),
         )
     assert excinfo.value.args == (
-        'Use dashes for package names {}: foo_bar==1'.format(tmpfile.strpath),
+        f'Use dashes for package names {tmpfile.strpath}: foo_bar==1',
     )
 
 
@@ -606,7 +595,7 @@ def test_check_requirements_integrity_failing(in_tmpdir):
 
 @pytest.mark.parametrize('version', ('2.13-1', '2.13.post1'))
 def test_check_requirements_integrity_post_version(in_tmpdir, version):
-    in_tmpdir.join('requirements.txt').write('chameleon=={}'.format(version))
+    in_tmpdir.join('requirements.txt').write(f'chameleon=={version}')
     main._check_requirements_integrity_impl()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py37
+envlist = py38
 
 [testenv]
 deps = -rrequirements-dev.txt
+allowlist_externals = {toxinidir}/testing/install-testing-packages.py
 commands =
     {toxinidir}/testing/install-testing-packages.py
     coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py37
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
I initially started looking into a deprecation warning on 3.11. [PEP 594](https://peps.python.org/pep-0594/#pipes) removes the `pipes` module in 3.13. `pipes.quote` is an alias to [`shlex.quote`](https://docs.python.org/3.10/library/shlex.html#shlex.quote) (since 3.3): [python/cpython/Lib/pipes.py#L64-66](https://github.com/python/cpython/blob/bf9cccb2b54ad2c641ea78435a8618a6d251491e/Lib/pipes.py#L63-L65).

I then noticed that tests were failing: When `pkg_resources.Requirement.parse(...)` fails, it does not raise `RequirementParseError`, but `packaging.InvalidRequirement` via the vendored `packaging` within `setuptools`. So I had to change this to `ValueError` to get the tests passing again. The vendored `InvalidRequirement` is intentionally not exposed via `pkg_resources` (?) - any better solution (more specific exception) would be appreciated though...

Also previously the CI was failing, since 3.6 is not available anymore. I upgraded to 3.7. The ubuntu 18.04 image is also deprecated, so I updated it to 22.04 - I hope that's okay and works.
